### PR TITLE
use HTTPS for loading D3

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@
 
     <script src="js/moment.js"></script>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-    <script src="http://d3js.org/d3.v3.min.js"></script>
+    <script src="https://d3js.org/d3.v3.min.js"></script>
     <script src='https://api.tiles.mapbox.com/mapbox.js/v1.6.4/mapbox.js'></script>
     <script src="js/script.js"></script>
 


### PR DESCRIPTION
Chrome blocks mixed content otherwise.

![screen shot 2017-08-10 at 9 37 20 pm](https://user-images.githubusercontent.com/86842/29198728-9acecbf4-7e14-11e7-9e89-efbd2158ca01.png)
